### PR TITLE
RD-5590 Stop rsyslog errors on community

### DIFF
--- a/packages-urls/manager-packages-aarch.yaml
+++ b/packages-urls/manager-packages-aarch.yaml
@@ -18,6 +18,9 @@ https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-7-aarch64/postgresq
 http://mirror.centos.org/altarch/7/os/aarch64/Packages/python-psycopg2-2.5.1-4.el7.aarch64.rpm
 http://mirror.centos.org/altarch/7/os/aarch64/Packages/patch-2.7.1-12.el7_7.aarch64.rpm
 http://mirror.centos.org/altarch/7/os/aarch64/Packages/haproxy-1.5.18-9.el7.aarch64.rpm
+http://mirror.centos.org/altarch/7/os/aarch64/Packages/libestr-0.1.9-2.el7.aarch64.rpm
+http://mirror.centos.org/altarch/7/os/aarch64/Packages/libfastjson-0.99.4-3.el7.aarch64.rpm
+http://mirror.centos.org/altarch/7/os/aarch64/Packages/rsyslog-8.24.0-55.el7.aarch64.rpm
 https://download-ib01.fedoraproject.org/pub/epel/7/aarch64/Packages/h/haveged-1.9.1-1.el7.aarch64.rpm
 https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/.dev1-release/cloudify-cli-7.0.0-.dev1.el7.aarch64.rpm
 https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/.dev1-release/cloudify-stage-7.0.0-.dev1.el7.aarch64.rpm

--- a/packages-urls/manager-packages.yaml
+++ b/packages-urls/manager-packages.yaml
@@ -17,6 +17,9 @@ https://repository.cloudifysource.org/cloudify/components/postgresql14-libs-14.4
 https://repository.cloudifysource.org/cloudify/components/postgresql14-server-14.4-1PGDG.rhel7.x86_64.rpm
 https://repository.cloudifysource.org/cloudify/components/python-psycopg2-2.5.1-3.el7.x86_64.rpm
 https://repository.cloudifysource.org/cloudify/components/patch-2.7.1-10.el7_5.x86_64.rpm
+https://repository.cloudifysource.org/cloudify/components/libestr-0.1.9-2.el7.x86_64.rpm
+https://repository.cloudifysource.org/cloudify/components/libfastjson-0.99.4-3.el7.x86_64.rpm
+https://repository.cloudifysource.org/cloudify/components/rsyslog-8.24.0-41.el7_7.x86_64.rpm
 https://repository.cloudifysource.org/cloudify/components/haveged-1.9.13-1.el7.x86_64.rpm
 https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/.dev1-release/cloudify-cli-7.0.0-.dev1.el7.x86_64.rpm
 https://cloudify-release-eu.s3.amazonaws.com/cloudify/7.0.0/.dev1-release/cloudify-stage-7.0.0-.dev1.el7.x86_64.rpm


### PR DESCRIPTION
Community docker images get a whole pile of spam as the rsyslog service restarts continually. This is because the file it's trying to run isn't there.